### PR TITLE
explore what indentation handling looks like

### DIFF
--- a/src/compiler/frontend/grammar.lalrpop
+++ b/src/compiler/frontend/grammar.lalrpop
@@ -1,12 +1,13 @@
 use crate::compiler::position::Position;
-use crate::compiler::frontend::tokenizer::{LexicalError, Token};
+use crate::compiler::frontend::tokenizer::Token;
+use crate::compiler::frontend::indentation::Error;
 use crate::compiler::frontend::*;
 
 grammar;
 
 extern {
     type Location = Position;
-    type Error = LexicalError;
+    type Error = Error;
 
     enum Token {
         // literals

--- a/src/compiler/frontend/indentation.rs
+++ b/src/compiler/frontend/indentation.rs
@@ -1,21 +1,22 @@
 //! Simplify the indentation manager for the parser
 //! by doing it in before the token iterator is passed to the parser.
 
-use super::tokenizer::{Spanned, Token, LexicalError};
+use super::tokenizer::{LexicalError, Spanned, Token};
 use crate::compiler::position::Position;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Error {
     LexicalError(LexicalError),
+    IndentationError { context: Context, spanned: Spanned },
     NotInitialized,
 }
 
 pub fn layout<I: Iterator<Item = Result<Spanned, LexicalError>>>(
     iter: I,
 ) -> impl Iterator<Item = Result<Spanned, Error>> {
-    let mut l = Layout { 
+    let mut l = Layout {
         tokens: iter,
-        indentation: vec![],
+        contexts: vec![],
         processed_tokens: vec![],
         lookahead: (Err(Error::NotInitialized), Err(Error::NotInitialized)),
     };
@@ -28,11 +29,12 @@ pub fn layout<I: Iterator<Item = Result<Spanned, LexicalError>>>(
 }
 
 /// Context represent the kind of expression we are looking at.
-/// 
+///
 /// It let us associate context-aware indentation rules
-enum Context {
+#[derive(Debug, PartialEq, Clone)]
+pub enum Context {
     /// This is a type context with its indentation level
-    Type(u8),
+    Type(Option<u8>),
 }
 
 /// The Layout struct is an iterator over a serie of Spanned tokens
@@ -49,9 +51,9 @@ struct Layout<I> {
     /// The source iterator
     tokens: I,
     /// The current level of indentation
-    indentation: Vec<Context>,
+    contexts: Vec<Context>,
     /// Buffer of processed tokens ready to be emitted.
-    /// 
+    ///
     /// We need this buffer as some tokens needs to lookahead in the source
     /// tokens. And as we don't want to lose any tokens, we need to put those
     /// somewhere until the consumer ask for them.
@@ -60,20 +62,20 @@ struct Layout<I> {
     lookahead: (Result<Spanned, Error>, Result<Spanned, Error>),
 }
 
-impl<I> Layout<I> 
+impl<I> Layout<I>
 where
     I: Iterator<Item = Result<Spanned, LexicalError>>,
 {
-
     /// A simple function which manage the internal lookahead structure
     /// in tandem with the source iterator.
-    /// 
+    ///
     /// It also convert the end of the source iterator into `Token::EndOfFile`.
     fn next_token(&mut self) -> Result<Spanned, Error> {
         let current = self.lookahead.0.clone(); // should probably use reference here
 
         self.lookahead.0 = self.lookahead.1.clone();
-        self.lookahead.1 =  self.tokens
+        self.lookahead.1 = self
+            .tokens
             .next()
             .unwrap_or_else(|| {
                 // This position is discarded, so can be rubish
@@ -88,56 +90,30 @@ where
 
     /// This is the main function of this iterator. It's in charge of detecting
     /// and applying the indentation logic.
+    ///
+    /// This function always assume it is called on the beginning of a new line
+    /// and will consume all tokens of the line before returning.
     fn consume(&mut self) {
-        match self.lookahead.0 {
+        let current_indent = self.consume_indent();
+        let current_context = self.contexts.last();
+
+        match (self.lookahead.0.as_ref(), current_context) {
             // end early if we have reached the end of the stream and deindented everything.
-            Ok((_, Token::EndOfFile, _)) => {
+            (Ok((_, Token::EndOfFile, _)), _) => {
                 // TODO Check indentation_level
                 let token = self.next_token();
                 self.emit(token);
                 return;
             }
 
-            Ok((_, Token::Type, _)) => {
-                // We enter a type definition section
+            // We enter a type definition section. They can only happens without indentation,
+            // hence there must be no context available.
+            (Ok((_, Token::Type, _)), None) => {
+                // We enter a type definition section (but we don't know the indent yet)
+                self.contexts.push(Context::Type(None));
+
                 // Let's emit the current line
-                let token = self.next_token();
-                self.emit(token);
                 self.emit_to_end_of_line();
-
-                // Here self.lookahead.0 should point to the first token on the next line
-
-                match self.lookahead.0 {
-                    // If a new line immediately, the type definition was a one-liner
-                    // let's emit the token and stop the current layout
-                    Ok((_,Token::Newline,_)) => {
-                        let next = self.next_token();
-                        self.emit(next);
-                        return
-                    },
-
-                    Ok((_,Token::Indent,_)) => {
-                        // Ok, we probably have a multi line definition here
-                        let indent = self.consume_indent();
-
-                        match self.lookahead.0 {
-                            Ok((_, Token::Equal, _))
-                            | Ok((_, Token::Pipe, _)) => {
-                                // We have a pipe declaration
-                            },
-                            _ => {
-                                // Not sure what we have here
-                            }
-                        }
-                        self.indentation.push(Context::Type(indent));
-
-                        // Now we are looking at the end of the indent section
-                        // TODO
-                        
-                    },
-                    // Probably a syntax error, let the parser deal with this case
-                    _ => return,
-                }
 
                 // Alg:
                 // 1. Skip to end of the line
@@ -147,22 +123,55 @@ where
                 //           skip line, look at next line: nothing => exit, otherwise require number of indent
             }
 
-            // Another type of token, let's just return it
+            // If we have an empty line with a type context, it means we can end the context
+            (Ok((_, Token::Newline, _)), Some(Context::Type(_))) => {
+                self.contexts.pop();
+                let token = self.next_token();
+                self.emit(token);
+            }
+
+            // Here we have a type definition context open and we found a delimiter token (= or |)
+            (Ok(spanned @ (_, Token::Equal, _)), Some(Context::Type(type_indent)))
+            | (Ok(spanned @ (_, Token::Pipe, _)), Some(Context::Type(type_indent))) => {
+                match type_indent {
+                    Some(i) => {
+                        // We have an indent to match
+                        if i != &current_indent {
+                            // Indent mismatch, let's emit an error
+                            // TODO
+                            self.processed_tokens.push(Err(Error::IndentationError {
+                                context: Context::Type(Some(*i)),
+                                spanned: spanned.clone(),
+                            }))
+                        }
+                    }
+                    None => {
+                        // We don't have any indentation recorded yet, let's set it up
+                        self.contexts.pop();
+                        self.contexts.push(Context::Type(Some(current_indent)));
+                    }
+                }
+
+                // Then consume the rest of the line
+                self.emit_to_end_of_line();
+            }
+
+            // Another type of token, let's just emit it as is
             _ => {
                 let token = self.next_token();
                 self.emit(token)
-            },
+            }
         }
     }
 
     /// consume the tokens until a non-`Token::Indent` token is found and
     /// return the number of such tokens consumed.
-    /// 
+    ///
     /// `lookahead.0` will be left pointing at the first non-indent token found
     fn consume_indent(&mut self) -> u8 {
         let mut indent = 0;
 
-        loop {            
+        loop {
             if let Ok((_, Token::Indent, _)) = self.lookahead.0 {
                 indent += 1;
                 self.next_token(); // skip over the indent token
@@ -174,7 +183,6 @@ where
 
         indent
     }
-
 
     //
     // Utility functions
@@ -209,12 +217,167 @@ where
         // Let's fill the processed_tokens queue if it's empty
         while self.processed_tokens.is_empty() {
             self.consume();
-        }        
+        }
 
         // We have something to emit, let's consume the queue
         match self.processed_tokens.remove(0) {
             Ok((_, Token::EndOfFile, _)) => None,
-            tok => Some(tok)
+            tok => Some(tok),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compiler::frontend::*;
+    use crate::compiler::position::Position;
+    use tokenizer::Token;
+
+    // Create an approximation for the token position in the stream.
+    // We don't count the spaces between tokens, but it gives us enough
+    // to understand where a failure happened.
+    fn tokens_to_spanned(tokens: &Vec<Token>) -> Vec<Result<Spanned, LexicalError>> {
+        let mut pos = Position::new(0, 0);
+
+        tokens
+            .into_iter()
+            .cloned()
+            .map(|token| {
+                let start = pos.clone();
+                let inc = match &token {
+                    Token::Module => 6,
+                    Token::Identifier { name } => name.len() as u32,
+                    Token::Exposing => 8,
+                    Token::LPar | Token::RPar => 1,
+                    Token::Comma => 1,
+                    Token::Indent => 2,
+                    Token::Pipe => 1,
+                    _ => 0,
+                };
+
+                pos.go_right_by(inc);
+
+                if token == Token::Newline {
+                    pos.newline();
+                }
+
+                let end = pos.clone();
+
+                Ok((start, token, end))
+            })
+            .collect()
+    }
+
+    fn ident_token(s: &str) -> Token {
+        Token::Identifier {
+            name: s.to_string(),
+        }
+    }
+
+    #[test]
+    fn emit_module_declaration() {
+        let module_tokens = vec![
+            Token::Module,
+            ident_token("Main"),
+            Token::Exposing,
+            Token::LPar,
+            ident_token("main"),
+            Token::RPar,
+            Token::Newline,
+        ];
+
+        let v: Vec<_> = layout(tokens_to_spanned(&module_tokens).into_iter())
+            .map(|x| x.expect("no error in layout").1)
+            .collect();
+
+        assert_eq!(v, module_tokens);
+    }
+
+    #[test]
+    fn emit_type_declaration_ok() {
+        let v: Vec<_> = layout(
+            tokens_to_spanned(&vec![
+                Token::Type,
+                ident_token("Maybe"),
+                ident_token("a"),
+                Token::Newline,
+                Token::Indent,
+                Token::Equal,
+                ident_token("Just"),
+                ident_token("a"),
+                Token::Newline,
+                Token::Indent,
+                Token::Pipe,
+                ident_token("Nothing"),
+                Token::Newline,
+            ])
+            .into_iter(),
+        )
+        .map(|x| x.expect("no error in layout").1)
+        .collect();
+
+        assert_eq!(
+            v,
+            vec![
+                Token::Type,
+                ident_token("Maybe"),
+                ident_token("a"),
+                Token::Newline,
+                Token::Equal,
+                ident_token("Just"),
+                ident_token("a"),
+                Token::Newline,
+                Token::Pipe,
+                ident_token("Nothing"),
+                Token::Newline,
+            ]
+        );
+    }
+
+    #[test]
+    fn emit_type_declaration_error() {
+        let v: Vec<_> = layout(
+            tokens_to_spanned(&vec![
+                Token::Type,
+                ident_token("Maybe"),
+                ident_token("a"),
+                Token::Newline,
+                Token::Indent,
+                Token::Equal,
+                ident_token("Just"),
+                ident_token("a"),
+                Token::Newline,
+                Token::Indent,
+                Token::Indent, // Here we have one indent too many
+                Token::Pipe,
+                ident_token("Nothing"),
+                Token::Newline,
+            ])
+            .into_iter(),
+        )
+        .map(|x| x.map(|s| s.1))
+        .collect();
+
+        assert_eq!(
+            v,
+            vec![
+                Ok(Token::Type),
+                Ok(ident_token("Maybe")),
+                Ok(ident_token("a")),
+                Ok(Token::Newline),
+                Ok(Token::Equal),
+                Ok(ident_token("Just")),
+                Ok(ident_token("a")),
+                Ok(Token::Newline),
+                Err(Error::IndentationError {
+                    context: Context::Type(Some(1)),
+                    spanned: (Position::new(2, 4), Token::Pipe, Position::new(2,5)),
+                }),
+                Ok(Token::Pipe),
+                Ok(ident_token("Nothing")),
+                Ok(Token::Newline),
+            ]
+        );
     }
 }

--- a/src/compiler/frontend/indentation.rs
+++ b/src/compiler/frontend/indentation.rs
@@ -1,0 +1,174 @@
+//! Simplify the indentation manager for the parser
+//! by doing it in before the token iterator is passed to the parser.
+
+use super::tokenizer::{Result, Spanned, Token};
+use crate::compiler::position::Position;
+
+pub fn layout<I: Iterator<Item = Result<Spanned>>>(
+    iter: I,
+) -> impl Iterator<Item = Result<Spanned>> {
+    Layout { 
+        tokens: iter,
+        indentation: vec![],
+        processed_tokens: vec![],
+    }
+}
+
+/// Context represent the kind of expression we are looking at.
+/// 
+/// It let us associate context-aware indentation rules
+enum Context {
+    /// This is a type context with its indentation level
+    Type(u8),
+}
+
+/// The Layout struct is an iterator over a serie of Spanned tokens
+/// which is managing some indentation rules.
+///
+/// It does so by having a context for the current token. A context
+/// represent what kind of terms we are looking at and what indentation
+/// rules we should apply.
+///
+struct Layout<I> {
+    tokens: I,
+    indentation: Vec<Context>,
+    /// Buffer of processed tokens ready to be emitted.
+    /// 
+    /// We need this buffer as some tokens needs to lookahead in the source
+    /// tokens. And as we don't want to lose any tokens, we need to put those
+    /// somewhere until the consumer ask for them.
+    processed_tokens: Vec<Result<Spanned>>,
+}
+
+impl<I> Layout<I> 
+where
+    I: Iterator<Item = Result<Spanned>>,
+{
+    /// utility to transform the source None into an EndOfFile
+    /// Not entirely sure if I need this function actually.
+    fn next_token(&mut self) -> Result<Spanned> {
+        self.tokens
+            .next()
+            .unwrap_or_else(|| {
+                // This position is discarded, so can be rubish
+                let position = Position::new(0, 0);
+
+                Ok((position, Token::EndOfFile, position))
+            })
+    }
+
+    /// This is the main function of this iterator. It's in charge of detecting
+    /// and applying the indentation logic.
+    fn layout(&mut self) -> Result<Spanned> {
+        let token = self.next_token()?;
+
+        // end early if we have reached the end of the stream and
+        // deindented everything.
+        if token.1 == Token::EndOfFile && self.indentation.is_empty() {
+            return Ok(token);
+        }
+
+        // Match the current token
+        match token.1 {
+            Token::Type => {
+                // We enter a type definition section
+                self.emit(Ok(token));
+                self.emit_until_end_of_line();
+                // Here we are at the beginning of the next line
+
+                loop {
+                    let next = self.next_token()?;
+
+                    match next.1 {
+                        // If a new line immediately, the type definition was a one-liner
+                        Token::Newline => break,
+
+                        Token::Indent => {
+                            // Ok, we probably have a multi line definition here
+                            let (indent, next_tok) = self.consume_indent();
+                            self.indentation.push(Context::Type(indent));
+
+                            // Now we are looking at the end of the indent section
+                            // TODO
+                            
+                        },
+                        // Probably a syntax error, let the parser deal with this case
+                        _ => break,
+                    }
+                }
+
+                // Alg:
+                // 1. Skip to end of the line
+                // 2. At next line,
+                //       if there is nothing exit the context
+                //       if there is indent+ followed by a =, count indent and store in context
+                //           skip line, look at next line: nothing => exit, otherwise require number of indent
+            },
+            _ => (),
+        }
+
+        todo!()
+    }
+
+
+    fn consume_indent(&mut self) -> (u8, Result<Spanned>) {
+        let mut indent = 0;
+        let mut next = self.next_token();
+
+        loop {            
+            if let Ok((_, Token::Indent, _)) = next {
+                indent += 1;
+            } else {
+                // We found a non-indent character, let's stop here
+                break;
+            }
+            
+            next = self.next_token();
+        }
+
+        (indent, next)
+    }
+
+
+    //
+    // Utility functions
+    //
+
+    fn emit(&mut self, tok: Result<Spanned>) {
+        self.processed_tokens.push(tok);
+    }
+
+    fn emit_until_end_of_line(&mut self) {
+        loop {
+            let next = self.next_token();
+            self.emit(next.clone()); // TODO Find a way to not clone here
+
+            match next {
+                Ok((_, Token::Newline, _)) => break,
+                Ok((_, Token::EndOfFile, _)) => break,
+                _ => (),
+            }
+        }
+    }
+}
+
+impl<I> Iterator for Layout<I>
+where
+    I: Iterator<Item = Result<Spanned>>,
+{
+    type Item = Result<Spanned>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // First let's emit the already processed tokens
+        if !self.processed_tokens.is_empty() {
+            return Some(self.processed_tokens.remove(0));
+        }
+
+        // We have catch-up with the already processed tokens, let's
+        // continue reading the source.
+        match self.layout() {
+            Ok((_, Token::EndOfFile, _)) => None,
+            tok => Some(tok)
+        }
+    }
+}

--- a/src/compiler/frontend/indentation.rs
+++ b/src/compiler/frontend/indentation.rs
@@ -1,17 +1,30 @@
 //! Simplify the indentation manager for the parser
 //! by doing it in before the token iterator is passed to the parser.
 
-use super::tokenizer::{Result, Spanned, Token};
+use super::tokenizer::{Spanned, Token, LexicalError};
 use crate::compiler::position::Position;
 
-pub fn layout<I: Iterator<Item = Result<Spanned>>>(
+#[derive(Debug, PartialEq, Clone)]
+pub enum Error {
+    LexicalError(LexicalError),
+    NotInitialized,
+}
+
+pub fn layout<I: Iterator<Item = Result<Spanned, LexicalError>>>(
     iter: I,
-) -> impl Iterator<Item = Result<Spanned>> {
-    Layout { 
+) -> impl Iterator<Item = Result<Spanned, Error>> {
+    let mut l = Layout { 
         tokens: iter,
         indentation: vec![],
         processed_tokens: vec![],
-    }
+        lookahead: (Err(Error::NotInitialized), Err(Error::NotInitialized)),
+    };
+
+    // Fill out the lookahead structure
+    l.next_token();
+    l.next_token();
+
+    l
 }
 
 /// Context represent the kind of expression we are looking at.
@@ -29,25 +42,38 @@ enum Context {
 /// represent what kind of terms we are looking at and what indentation
 /// rules we should apply.
 ///
+/// TODO: I really need to use references with this one. There are too many
+/// `clone()` call on something which is part of the core loop. Let's do so
+/// once I have a somewhat working algorithm.
 struct Layout<I> {
+    /// The source iterator
     tokens: I,
+    /// The current level of indentation
     indentation: Vec<Context>,
     /// Buffer of processed tokens ready to be emitted.
     /// 
     /// We need this buffer as some tokens needs to lookahead in the source
     /// tokens. And as we don't want to lose any tokens, we need to put those
     /// somewhere until the consumer ask for them.
-    processed_tokens: Vec<Result<Spanned>>,
+    processed_tokens: Vec<Result<Spanned, Error>>,
+    /// The current token (and the next one)
+    lookahead: (Result<Spanned, Error>, Result<Spanned, Error>),
 }
 
 impl<I> Layout<I> 
 where
-    I: Iterator<Item = Result<Spanned>>,
+    I: Iterator<Item = Result<Spanned, LexicalError>>,
 {
-    /// utility to transform the source None into an EndOfFile
-    /// Not entirely sure if I need this function actually.
-    fn next_token(&mut self) -> Result<Spanned> {
-        self.tokens
+
+    /// A simple function which manage the internal lookahead structure
+    /// in tandem with the source iterator.
+    /// 
+    /// It also convert the end of the source iterator into `Token::EndOfFile`.
+    fn next_token(&mut self) -> Result<Spanned, Error> {
+        let current = self.lookahead.0.clone(); // should probably use reference here
+
+        self.lookahead.0 = self.lookahead.1.clone();
+        self.lookahead.1 =  self.tokens
             .next()
             .unwrap_or_else(|| {
                 // This position is discarded, so can be rubish
@@ -55,46 +81,62 @@ where
 
                 Ok((position, Token::EndOfFile, position))
             })
+            .map_err(Error::LexicalError);
+
+        current
     }
 
     /// This is the main function of this iterator. It's in charge of detecting
     /// and applying the indentation logic.
-    fn layout(&mut self) -> Result<Spanned> {
-        let token = self.next_token()?;
+    fn consume(&mut self) {
+        match self.lookahead.0 {
+            // end early if we have reached the end of the stream and deindented everything.
+            Ok((_, Token::EndOfFile, _)) => {
+                // TODO Check indentation_level
+                let token = self.next_token();
+                self.emit(token);
+                return;
+            }
 
-        // end early if we have reached the end of the stream and
-        // deindented everything.
-        if token.1 == Token::EndOfFile && self.indentation.is_empty() {
-            return Ok(token);
-        }
-
-        // Match the current token
-        match token.1 {
-            Token::Type => {
+            Ok((_, Token::Type, _)) => {
                 // We enter a type definition section
-                self.emit(Ok(token));
-                self.emit_until_end_of_line();
-                // Here we are at the beginning of the next line
+                // Let's emit the current line
+                let token = self.next_token();
+                self.emit(token);
+                self.emit_to_end_of_line();
 
-                loop {
-                    let next = self.next_token()?;
+                // Here self.lookahead.0 should point to the first token on the next line
 
-                    match next.1 {
-                        // If a new line immediately, the type definition was a one-liner
-                        Token::Newline => break,
+                match self.lookahead.0 {
+                    // If a new line immediately, the type definition was a one-liner
+                    // let's emit the token and stop the current layout
+                    Ok((_,Token::Newline,_)) => {
+                        let next = self.next_token();
+                        self.emit(next);
+                        return
+                    },
 
-                        Token::Indent => {
-                            // Ok, we probably have a multi line definition here
-                            let (indent, next_tok) = self.consume_indent();
-                            self.indentation.push(Context::Type(indent));
+                    Ok((_,Token::Indent,_)) => {
+                        // Ok, we probably have a multi line definition here
+                        let indent = self.consume_indent();
 
-                            // Now we are looking at the end of the indent section
-                            // TODO
-                            
-                        },
-                        // Probably a syntax error, let the parser deal with this case
-                        _ => break,
-                    }
+                        match self.lookahead.0 {
+                            Ok((_, Token::Equal, _))
+                            | Ok((_, Token::Pipe, _)) => {
+                                // We have a pipe declaration
+                            },
+                            _ => {
+                                // Not sure what we have here
+                            }
+                        }
+                        self.indentation.push(Context::Type(indent));
+
+                        // Now we are looking at the end of the indent section
+                        // TODO
+                        
+                    },
+                    // Probably a syntax error, let the parser deal with this case
+                    _ => return,
                 }
 
                 // Alg:
@@ -103,30 +145,34 @@ where
                 //       if there is nothing exit the context
                 //       if there is indent+ followed by a =, count indent and store in context
                 //           skip line, look at next line: nothing => exit, otherwise require number of indent
-            },
-            _ => (),
-        }
+            }
 
-        todo!()
+            // Another type of token, let's just return it
+            _ => {
+                let token = self.next_token();
+                self.emit(token)
+            },
+        }
     }
 
-
-    fn consume_indent(&mut self) -> (u8, Result<Spanned>) {
+    /// consume the tokens until a non-`Token::Indent` token is found and
+    /// return the number of such tokens consumed.
+    /// 
+    /// `lookahead.0` will be left pointing at the first non-indent token found
+    fn consume_indent(&mut self) -> u8 {
         let mut indent = 0;
-        let mut next = self.next_token();
 
         loop {            
-            if let Ok((_, Token::Indent, _)) = next {
+            if let Ok((_, Token::Indent, _)) = self.lookahead.0 {
                 indent += 1;
+                self.next_token(); // skip over the indent token
             } else {
                 // We found a non-indent character, let's stop here
                 break;
             }
-            
-            next = self.next_token();
         }
 
-        (indent, next)
+        indent
     }
 
 
@@ -134,15 +180,16 @@ where
     // Utility functions
     //
 
-    fn emit(&mut self, tok: Result<Spanned>) {
+    fn emit(&mut self, tok: Result<Spanned, Error>) {
         self.processed_tokens.push(tok);
     }
 
-    fn emit_until_end_of_line(&mut self) {
+    fn emit_to_end_of_line(&mut self) {
         loop {
             let next = self.next_token();
             self.emit(next.clone()); // TODO Find a way to not clone here
 
+            // Breaking here means we have already emitted the nl/eof token
             match next {
                 Ok((_, Token::Newline, _)) => break,
                 Ok((_, Token::EndOfFile, _)) => break,
@@ -154,19 +201,18 @@ where
 
 impl<I> Iterator for Layout<I>
 where
-    I: Iterator<Item = Result<Spanned>>,
+    I: Iterator<Item = Result<Spanned, LexicalError>>,
 {
-    type Item = Result<Spanned>;
+    type Item = Result<Spanned, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // First let's emit the already processed tokens
-        if !self.processed_tokens.is_empty() {
-            return Some(self.processed_tokens.remove(0));
-        }
+        // Let's fill the processed_tokens queue if it's empty
+        while self.processed_tokens.is_empty() {
+            self.consume();
+        }        
 
-        // We have catch-up with the already processed tokens, let's
-        // continue reading the source.
-        match self.layout() {
+        // We have something to emit, let's consume the queue
+        match self.processed_tokens.remove(0) {
             Ok((_, Token::EndOfFile, _)) => None,
             tok => Some(tok)
         }

--- a/src/compiler/frontend/mod.rs
+++ b/src/compiler/frontend/mod.rs
@@ -5,6 +5,7 @@
 //! syntax sugar to make their life easier. For example, pattern matching
 //! in function declaration is one such thing.
 //!
+pub mod indentation;
 pub mod parser;
 pub mod tokenizer;
 

--- a/src/compiler/frontend/parser.rs
+++ b/src/compiler/frontend/parser.rs
@@ -1,15 +1,16 @@
 //! Transform a serie of tokens into the frontend AST.
 
 use super::Module;
-use crate::compiler::frontend::tokenizer::{self, LexicalError, Spanned, Token};
+use crate::compiler::frontend::tokenizer::{self, Spanned, Token};
+use crate::compiler::frontend::indentation::Error;
 use crate::compiler::position::Position;
 use lalrpop_util::ParseError;
 
 lalrpop_mod!(grammar, "/compiler/frontend/grammar.rs");
 
 pub fn parse(
-    i: impl Iterator<Item = tokenizer::Result<Spanned>>,
-) -> Result<Module, ParseError<Position, Token, LexicalError>> {
+    i: impl Iterator<Item = Result<Spanned, Error>>,
+) -> Result<Module, ParseError<Position, Token, Error>> {
     grammar::ModuleParser::new().parse(i)
 }
 

--- a/src/compiler/frontend/tokenizer.rs
+++ b/src/compiler/frontend/tokenizer.rs
@@ -86,7 +86,7 @@ fn get_keywords() -> HashMap<String, Token> {
 
 // TODO Rename to TokenizerError
 /// Represents an error during tokenization.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct LexicalError {
     pub error: LexicalErrorType,
     pub position: Position,
@@ -94,7 +94,7 @@ pub struct LexicalError {
 
 // TODO Remove errors that aren't needed
 /// The type of error refered in `LexicalError`
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum LexicalErrorType {
     CharError,
     StringError,  // TODO String literal

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -25,7 +25,6 @@ pub fn compile_file<P: AsRef<Path>>(path: P) {
             .collect::<Vec<_>>()
     );
 
-    
     // parser
     let ast = frontend::parser::parse(tokens.into_iter());
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -10,7 +10,9 @@ pub fn compile_file<P: AsRef<Path>>(path: P) {
 
     // This is the first pass of our "compiler"
     let tokenizer = frontend::tokenizer::make_tokenizer(&source);
-    let tokens: Vec<_> = tokenizer.collect();
+    // TODO Insert indentation between tokenizer and tokens
+    let indented = frontend::indentation::layout(frontend::tokenizer::make_tokenizer(&source));
+    let tokens: Vec<_> = indented.collect();
     println!(
         "frontend token errors: {:?}",
         tokens.iter().filter(|r| r.is_err()).collect::<Vec<_>>()
@@ -26,6 +28,8 @@ pub fn compile_file<P: AsRef<Path>>(path: P) {
     );
 
     // parser
+    // TODO Needs to use indentation::Error now, which lead me to think we should probably
+    // have a frontend::Error enum instead of each module taking over the previous one.
     let ast = frontend::parser::parse(tokens.into_iter());
 
     // TODO Be a bit smarter in how we show the tokens above, instead of taking the first


### PR DESCRIPTION
The idea being to handle indentation levels before going in the parser.

Not entirely certain what the best way of doing so would be, because it's somewhat linked. For example, the indentation handler needs to know that a `type` token can be multiline and have some form of parser-like semantic to handle those cases. Hopefully this PR will make things clearer to me.